### PR TITLE
Add internationalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,9 @@ require (
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/imroc/req/v3 v3.14.0
+	github.com/nicksnyder/go-i18n/v2 v2.2.0
+	golang.org/x/text v0.3.7
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -47,7 +50,6 @@ require (
 	golang.org/x/net v0.0.0-20220630215102-69896b714898 // indirect
 	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/charmbracelet/bubbles v0.13.0
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/charmbracelet/lipgloss v0.5.0
-	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
 	github.com/imroc/req/v3 v3.14.0
 	github.com/nicksnyder/go-i18n/v2 v2.2.0
 	golang.org/x/text v0.3.7
@@ -20,6 +19,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
+	github.com/cubiest/jibberjabber v1.0.1
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/charmbracelet/bubbles v0.13.0
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/charmbracelet/lipgloss v0.5.0
+	github.com/imroc/req/v3 v3.14.1
 	github.com/nicksnyder/go-i18n/v2 v2.2.0
 	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
-	github.com/imroc/req/v3 v3.14.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v0.13.0
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/charmbracelet/lipgloss v0.5.0
+	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
 	github.com/imroc/req/v3 v3.14.0
 	github.com/nicksnyder/go-i18n/v2 v2.2.0
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -32,11 +32,11 @@ github.com/charmbracelet/lipgloss v0.5.0/go.mod h1:EZLha/HbzEt7cYqdFPovlqy5FZPj0
 github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:tuijfIjZyjZaHq9xDUh0tNitwXshJpbLkqMOJv4H3do=
-github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21/go.mod h1:po7NpZ/QiTKzBKyrsEAxwnTamCoh8uDk/egRpQ7siIc=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/cubiest/jibberjabber v1.0.1 h1:JxKC9EZcdw8azEbyWaNj62ppPMkbFJBf2ayPY1vBeDI=
+github.com/cubiest/jibberjabber v1.0.1/go.mod h1:Ovt9ZAmzAgwQ8cWgvZ1se9oaGYzjHrlAXKM3NOzlQOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/charmbracelet/lipgloss v0.5.0/go.mod h1:EZLha/HbzEt7cYqdFPovlqy5FZPj0
 github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:tuijfIjZyjZaHq9xDUh0tNitwXshJpbLkqMOJv4H3do=
+github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21/go.mod h1:po7NpZ/QiTKzBKyrsEAxwnTamCoh8uDk/egRpQ7siIc=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -98,9 +100,11 @@ github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucas-clemente/quic-go v0.28.0 h1:9eXVRgIkMQQyiyorz/dAaOYIx3TFzXsIFkNFz4cxuJM=
@@ -147,6 +151,8 @@ github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739 h1:QANkGiGr39l1E
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
+github.com/nicksnyder/go-i18n/v2 v2.2.0 h1:MNXbyPvd141JJqlU6gJKrczThxJy+kdCNivxZpBQFkw=
+github.com/nicksnyder/go-i18n/v2 v2.2.0/go.mod h1:4OtLfzqyAxsscyCb//3gfqSvBc81gImX91LrZzczN1o=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -354,6 +360,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,13 @@
 package config
 
+import (
+	"fmt"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/victorbersy/docker-hub-cli/internal/config/locales"
+	"github.com/victorbersy/docker-hub-cli/internal/ui/styles"
+)
+
 type ViewType string
 
 const (
@@ -33,6 +41,9 @@ type Config struct {
 }
 
 func GetDefaultConfig() Config {
+	localizer := locales.GetLocalizer()
+	explore_title := localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "tab_explore_title"})
+	my_repos_title := localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "tab_my_repos_title"})
 	return Config{
 		Defaults: Defaults{
 			Preview: PreviewConfig{
@@ -43,11 +54,11 @@ func GetDefaultConfig() Config {
 		},
 		Views: []ViewConfig{
 			{
-				Title: " Explore",
+				Title: fmt.Sprint(styles.DefaultGlyphs.TabExplore, " ", explore_title),
 				Type:  ExploreView,
 			},
 			{
-				Title: "  My Repositories",
+				Title: fmt.Sprint(styles.DefaultGlyphs.TabMyRepos, "  ", my_repos_title),
 				Type:  MyReposView,
 			},
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,8 @@ type Config struct {
 
 func GetDefaultConfig() Config {
 	localizer := locales.NewLocales()
-	explore_title := localizer.T("tab_explore_title")
-	my_repos_title := localizer.T("tab_my_repos_title")
+	explore_title := localizer.L("tab_explore_title")
+	my_repos_title := localizer.L("tab_my_repos_title")
 	return Config{
 		Defaults: Defaults{
 			Preview: PreviewConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/victorbersy/docker-hub-cli/internal/config/locales"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/styles"
 )
@@ -41,9 +40,9 @@ type Config struct {
 }
 
 func GetDefaultConfig() Config {
-	localizer := locales.GetLocalizer()
-	explore_title := localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "tab_explore_title"})
-	my_repos_title := localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "tab_my_repos_title"})
+	localizer := locales.NewLocales()
+	explore_title := localizer.T("tab_explore_title")
+	my_repos_title := localizer.T("tab_my_repos_title")
 	return Config{
 		Defaults: Defaults{
 			Preview: PreviewConfig{

--- a/internal/config/locales/en.yaml
+++ b/internal/config/locales/en.yaml
@@ -1,3 +1,10 @@
+startup_reading:
+  description:
+  other: "Reading config..."
+startup_no_views_defined:
+  description:
+  other: "No views defined..."
+
 tab_explore_title:
   description: "Top screen tab name"
   other: "Explore"

--- a/internal/config/locales/en.yaml
+++ b/internal/config/locales/en.yaml
@@ -27,7 +27,7 @@ explore_sidebar_architectures:
   other: "Architectures"
 explore_sidebar_how_to_pull_instructions:
   description: "Instructions on how to pull the selected image"
-  other: "How to pull"
+  other: "How to pull \"{{.Name}}\"?"
 
 my_repositories_item_type_label:
   description: "Label name used to identify the resource, like to count them"

--- a/internal/config/locales/en.yaml
+++ b/internal/config/locales/en.yaml
@@ -5,13 +5,13 @@ tab_my_repos_title:
   description: "Top screen tab name"
   other: "My repositories"
 
-explorer_repositories_item_type_label:
+explore_repositories_item_type_label:
   description: "Label name used to identify the resource, like to count them"
   other: "Repositories"
-explorer_repositories_not_found:
+explore_repositories_not_found:
   description: "Displayed when none are found"
   other: "No repositories found."
-explorer_repositories_fetching:
+explore_repositories_fetching:
   description: "Displayed when fetching repositories"
   other: "Fetching repositories..."
 

--- a/internal/config/locales/en.yaml
+++ b/internal/config/locales/en.yaml
@@ -15,6 +15,13 @@ explore_repositories_fetching:
   description: "Displayed when fetching repositories"
   other: "Fetching repositories..."
 
+explore_sidebar_architectures:
+  description: "Explore sidebar architectures title"
+  other: "Architectures"
+explore_sidebar_how_to_pull_instructions:
+  description: "Instructions on how to pull the selected image"
+  other: "How to pull"
+
 my_repositories_item_type_label:
   description: "Label name used to identify the resource, like to count them"
   other: "Repositories"
@@ -27,6 +34,28 @@ my_repositories_not_found_tip:
 my_repositories_fetching:
   description: "Displayed when fetching repositories"
   other: "Fetching repositories..."
+
+my_repos_sidebar_visibility:
+  description: ""
+  other: "Visibility"
+my_repos_sidebar_visibility_private:
+  description: ""
+  other: "Private"
+my_repos_sidebar_visibility_public:
+  description: ""
+  other: "Public"
+my_repos_sidebar_stats:
+  description: ""
+  other: "Stats"
+my_repos_sidebar_timestamps:
+  description: ""
+  other: "Timestamps"
+my_repos_sidebar_updated_at:
+  description: ""
+  other: "Last Update"
+my_repos_sidebar_created_at:
+  description: ""
+  other: "Created At"
 
 column_header_name:
   description: "Common table column header"

--- a/internal/config/locales/en.yaml
+++ b/internal/config/locales/en.yaml
@@ -1,0 +1,45 @@
+tab_explore_title:
+  description: "Top screen tab name"
+  other: "Explore"
+tab_my_repos_title:
+  description: "Top screen tab name"
+  other: "My repositories"
+
+explorer_repositories_item_type_label:
+  description: "Label name used to identify the resource, like to count them"
+  other: "Repositories"
+explorer_repositories_not_found:
+  description: "Displayed when none are found"
+  other: "No repositories found."
+explorer_repositories_fetching:
+  description: "Displayed when fetching repositories"
+  other: "Fetching repositories..."
+
+my_repositories_item_type_label:
+  description: "Label name used to identify the resource, like to count them"
+  other: "Repositories"
+my_repositories_not_found:
+  description: "Displayed when none are found"
+  other: "No repositories found."
+my_repositories_not_found_tip:
+  description: "Displayed when none are found"
+  other: "Have you set DOCKER_USERNAME and DOCKER_BEARER?"
+my_repositories_fetching:
+  description: "Displayed when fetching repositories"
+  other: "Fetching repositories..."
+
+column_header_name:
+  description: "Common table column header"
+  other: "Name"
+column_header_organization:
+  description: "Common table column header"
+  other: "Organization"
+column_header_updated_at:
+  description: "Common table column header"
+  other: "Updated At"
+column_header_created_at:
+  description: "Common table column header"
+  other: "Created At"
+column_header_description:
+  description: "Common table column header"
+  other: "Description"

--- a/internal/config/locales/fr.yaml
+++ b/internal/config/locales/fr.yaml
@@ -1,3 +1,10 @@
+startup_reading:
+  description:
+  other: "Récupération de la configuration..."
+startup_no_views_defined:
+  description:
+  other: "Aucune vues trouvées..."
+
 tab_explore_title:
   description: "Top screen tab name"
   other: "Explorer"

--- a/internal/config/locales/fr.yaml
+++ b/internal/config/locales/fr.yaml
@@ -5,13 +5,13 @@ tab_my_repos_title:
   description: "Top screen tab name"
   other: "Mes dépôts"
 
-explorer_repositories_item_type_label:
+explore_repositories_item_type_label:
   description: "Label name used to identify the resource, like to count them"
   other: "Dépôts"
-explorer_repositories_not_found:
+explore_repositories_not_found:
   description: "Displayed when none are found"
   other: "Aucun dépôt trouvé."
-explorer_repositories_fetching:
+explore_repositories_fetching:
   description: "Displayed when fetching repositories"
   other: "Récupération des dépôts..."
 

--- a/internal/config/locales/fr.yaml
+++ b/internal/config/locales/fr.yaml
@@ -1,0 +1,45 @@
+tab_explore_title:
+  description: "Top screen tab name"
+  other: "Explorer"
+tab_my_repos_title:
+  description: "Top screen tab name"
+  other: "Mes dépôts"
+
+explorer_repositories_item_type_label:
+  description: "Label name used to identify the resource, like to count them"
+  other: "Dépôts"
+explorer_repositories_not_found:
+  description: "Displayed when none are found"
+  other: "Aucun dépôt trouvé."
+explorer_repositories_fetching:
+  description: "Displayed when fetching repositories"
+  other: "Récupération des dépôts..."
+
+my_repositories_item_type_label:
+  description: "Label name used to identify the resource, like to count them"
+  other: "Dépôts"
+my_repositories_not_found:
+  description: "Displayed when none are found"
+  other: "Aucun de vos dépôts n'a été trouvé."
+my_repositories_not_found_tip:
+  description: "Displayed when none are found"
+  other: "Avez-vous configuré DOCKER_USERNAME et DOCKER_BEARER ?"
+my_repositories_fetching:
+  description: "Displayed when fetching repositories"
+  other: "Récupération des dépôts..."
+
+column_header_name:
+  description: "Column name used in explore view"
+  other: "Nom"
+column_header_organization:
+  description: "Column name used in explore view"
+  other: "Société"
+column_header_updated_at:
+  description: "Column name used in explore view"
+  other: "Dernière mise à jour"
+column_header_created_at:
+  description: "Column name used in explore view"
+  other: "Créé le"
+column_header_description:
+  description: "Column name used in explore view"
+  other: "Description"

--- a/internal/config/locales/fr.yaml
+++ b/internal/config/locales/fr.yaml
@@ -27,7 +27,7 @@ explore_sidebar_architectures:
   other: "Architectures"
 explore_sidebar_how_to_pull_instructions:
   description: "Instructions on how to pull the selected image"
-  other: "Comment obtenir"
+  other: "Comment obtenir \"{{.Name}}\" ?"
 
 my_repositories_item_type_label:
   description: "Label name used to identify the resource, like to count them"

--- a/internal/config/locales/fr.yaml
+++ b/internal/config/locales/fr.yaml
@@ -15,6 +15,13 @@ explore_repositories_fetching:
   description: "Displayed when fetching repositories"
   other: "Récupération des dépôts..."
 
+explore_sidebar_architectures:
+  description: "Explore sidebar architectures title"
+  other: "Architectures"
+explore_sidebar_how_to_pull_instructions:
+  description: "Instructions on how to pull the selected image"
+  other: "Comment obtenir"
+
 my_repositories_item_type_label:
   description: "Label name used to identify the resource, like to count them"
   other: "Dépôts"
@@ -27,6 +34,28 @@ my_repositories_not_found_tip:
 my_repositories_fetching:
   description: "Displayed when fetching repositories"
   other: "Récupération des dépôts..."
+
+my_repos_sidebar_visibility:
+  description: ""
+  other: "Visibilité"
+my_repos_sidebar_visibility_private:
+  description: ""
+  other: "Privé"
+my_repos_sidebar_visibility_public:
+  description: ""
+  other: "Publique"
+my_repos_sidebar_stats:
+  description: ""
+  other: "Stats"
+my_repos_sidebar_timestamps:
+  description: ""
+  other: "Dates"
+my_repos_sidebar_updated_at:
+  description: ""
+  other: "Dernière mise à jour"
+my_repos_sidebar_created_at:
+  description: ""
+  other: "Créé le"
 
 column_header_name:
   description: "Column name used in explore view"

--- a/internal/config/locales/locales.go
+++ b/internal/config/locales/locales.go
@@ -7,9 +7,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	default_language = language.English
-)
+var default_language = language.English
 
 type Locales struct {
 	Localizer *i18n.Localizer

--- a/internal/config/locales/locales.go
+++ b/internal/config/locales/locales.go
@@ -1,11 +1,14 @@
 package locales
 
 import (
-	"os"
-
+	"github.com/cloudfoundry/jibber_jabber"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"golang.org/x/text/language"
 	"gopkg.in/yaml.v2"
+)
+
+var (
+	default_language = language.English
 )
 
 type Locales struct {
@@ -13,12 +16,19 @@ type Locales struct {
 }
 
 func GetLocalizer() *i18n.Localizer {
-	default_language := language.English
 	bundle := i18n.NewBundle(default_language)
 	bundle.RegisterUnmarshalFunc("yaml", yaml.Unmarshal)
 	bundle.MustLoadMessageFile("./internal/config/locales/en.yaml")
 	bundle.MustLoadMessageFile("./internal/config/locales/fr.yaml")
-	return i18n.NewLocalizer(bundle, os.Getenv("LANG"), default_language.String())
+	return i18n.NewLocalizer(bundle, getLanguage().String(), default_language.String())
+}
+
+func getLanguage() language.Tag {
+	userLanguage, err := jibber_jabber.DetectLanguage()
+	if err != nil {
+		return default_language
+	}
+	return language.Make(userLanguage)
 }
 
 func (locales Locales) Localize(msgId string) string {

--- a/internal/config/locales/locales.go
+++ b/internal/config/locales/locales.go
@@ -37,6 +37,6 @@ func getLanguage() language.Tag {
 	return language.Make(userLanguage)
 }
 
-func (locales Locales) T(msgId string) string {
+func (locales Locales) L(msgId string) string {
 	return locales.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: msgId})
 }

--- a/internal/config/locales/locales.go
+++ b/internal/config/locales/locales.go
@@ -15,7 +15,13 @@ type Locales struct {
 	Localizer *i18n.Localizer
 }
 
-func GetLocalizer() *i18n.Localizer {
+func NewLocales() Locales {
+	return Locales{
+		Localizer: getLocalizer(),
+	}
+}
+
+func getLocalizer() *i18n.Localizer {
 	bundle := i18n.NewBundle(default_language)
 	bundle.RegisterUnmarshalFunc("yaml", yaml.Unmarshal)
 	bundle.MustLoadMessageFile("./internal/config/locales/en.yaml")
@@ -31,6 +37,6 @@ func getLanguage() language.Tag {
 	return language.Make(userLanguage)
 }
 
-func (locales Locales) Localize(msgId string) string {
+func (locales Locales) T(msgId string) string {
 	return locales.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: msgId})
 }

--- a/internal/config/locales/locales.go
+++ b/internal/config/locales/locales.go
@@ -1,7 +1,7 @@
 package locales
 
 import (
-	"github.com/cloudfoundry/jibber_jabber"
+	"github.com/cubiest/jibberjabber"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"golang.org/x/text/language"
 	"gopkg.in/yaml.v2"
@@ -24,7 +24,7 @@ func GetLocalizer() *i18n.Localizer {
 }
 
 func getLanguage() language.Tag {
-	userLanguage, err := jibber_jabber.DetectLanguage()
+	userLanguage, err := jibberjabber.DetectLanguage()
 	if err != nil {
 		return default_language
 	}

--- a/internal/config/locales/locales.go
+++ b/internal/config/locales/locales.go
@@ -1,0 +1,26 @@
+package locales
+
+import (
+	"os"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"golang.org/x/text/language"
+	"gopkg.in/yaml.v2"
+)
+
+type Locales struct {
+	Localizer *i18n.Localizer
+}
+
+func GetLocalizer() *i18n.Localizer {
+	default_language := language.English
+	bundle := i18n.NewBundle(default_language)
+	bundle.RegisterUnmarshalFunc("yaml", yaml.Unmarshal)
+	bundle.MustLoadMessageFile("./internal/config/locales/en.yaml")
+	bundle.MustLoadMessageFile("./internal/config/locales/fr.yaml")
+	return i18n.NewLocalizer(bundle, os.Getenv("LANG"), default_language.String())
+}
+
+func (locales Locales) Localize(msgId string) string {
+	return locales.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: msgId})
+}

--- a/internal/ui/components/sidebar/explore/explore.go
+++ b/internal/ui/components/sidebar/explore/explore.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 	data_search "github.com/victorbersy/docker-hub-cli/internal/data/search"
 	repository_search "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/search"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/components/sidebar"
@@ -75,7 +74,7 @@ func (m *Model) renderDescription() string {
 }
 
 func (m *Model) renderArchs() string {
-	architecture_title := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_sidebar_architectures"})
+	architecture_title := m.ctx.Localizer.T("explore_sidebar_architectures")
 	archs := []string{}
 	for _, arch := range m.repo.Data.Architectures {
 		archs = append(archs, archLabel.Render(arch.Name))
@@ -91,7 +90,7 @@ func (m *Model) renderArchs() string {
 }
 
 func (m *Model) renderPullCmd() string {
-	how_to_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_sidebar_how_to_pull_instructions"})
+	how_to_txt := m.ctx.Localizer.T("explore_sidebar_how_to_pull_instructions")
 	cmd := fmt.Sprintf("$ docker pull %s", m.repo.Data.Slug)
 	return lipgloss.JoinVertical(
 		lipgloss.Top,

--- a/internal/ui/components/sidebar/explore/explore.go
+++ b/internal/ui/components/sidebar/explore/explore.go
@@ -74,7 +74,7 @@ func (m *Model) renderDescription() string {
 }
 
 func (m *Model) renderArchs() string {
-	architecture_title := m.ctx.Localizer.T("explore_sidebar_architectures")
+	architecture_title := m.ctx.Localizer.L("explore_sidebar_architectures")
 	archs := []string{}
 	for _, arch := range m.repo.Data.Architectures {
 		archs = append(archs, archLabel.Render(arch.Name))
@@ -90,7 +90,7 @@ func (m *Model) renderArchs() string {
 }
 
 func (m *Model) renderPullCmd() string {
-	how_to_txt := m.ctx.Localizer.T("explore_sidebar_how_to_pull_instructions")
+	how_to_txt := m.ctx.Localizer.L("explore_sidebar_how_to_pull_instructions")
 	cmd := fmt.Sprintf("$ docker pull %s", m.repo.Data.Slug)
 	return lipgloss.JoinVertical(
 		lipgloss.Top,

--- a/internal/ui/components/sidebar/explore/explore.go
+++ b/internal/ui/components/sidebar/explore/explore.go
@@ -4,17 +4,20 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
 	data_search "github.com/victorbersy/docker-hub-cli/internal/data/search"
 	repository_search "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/search"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/components/sidebar"
+	"github.com/victorbersy/docker-hub-cli/internal/ui/context"
 )
 
 type Model struct {
 	repo  *repository_search.Repository
 	width int
+	ctx   *context.ProgramContext
 }
 
-func NewModel(data *data_search.Repository, width int) Model {
+func NewModel(data *data_search.Repository, width int, ctx *context.ProgramContext) Model {
 	var r *repository_search.Repository
 	if data == nil {
 		r = nil
@@ -24,6 +27,7 @@ func NewModel(data *data_search.Repository, width int) Model {
 	return Model{
 		repo:  r,
 		width: width,
+		ctx:   ctx,
 	}
 }
 
@@ -71,13 +75,14 @@ func (m *Model) renderDescription() string {
 }
 
 func (m *Model) renderArchs() string {
+	architecture_title := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_sidebar_architectures"})
 	archs := []string{}
 	for _, arch := range m.repo.Data.Architectures {
 		archs = append(archs, archLabel.Render(arch.Name))
 	}
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		archsTitle.Render("Archs"),
+		archsTitle.Render(architecture_title),
 		lipgloss.JoinHorizontal(
 			lipgloss.Top,
 			archs...,
@@ -86,10 +91,11 @@ func (m *Model) renderArchs() string {
 }
 
 func (m *Model) renderPullCmd() string {
+	how_to_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_sidebar_how_to_pull_instructions"})
 	cmd := fmt.Sprintf("$ docker pull %s", m.repo.Data.Slug)
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		dockerPullCmdTitle.Render(fmt.Sprintf("How to pull %s?", m.repo.Data.Name)),
+		dockerPullCmdTitle.Render(fmt.Sprintf("%s %s?", how_to_txt, m.repo.Data.Name)), // TODO: use translation template
 		dockerPullCmdBox.Copy().Render(cmd),
 	)
 }

--- a/internal/ui/components/sidebar/explore/explore.go
+++ b/internal/ui/components/sidebar/explore/explore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
 	data_search "github.com/victorbersy/docker-hub-cli/internal/data/search"
 	repository_search "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/search"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/components/sidebar"
@@ -90,11 +91,16 @@ func (m *Model) renderArchs() string {
 }
 
 func (m *Model) renderPullCmd() string {
-	how_to_txt := m.ctx.Localizer.L("explore_sidebar_how_to_pull_instructions")
+	howToPullInstructions := &i18n.Message{ID: "explore_sidebar_how_to_pull_instructions"}
+	howToPullInstructionsTemplate := map[string]interface{}{"Name": m.repo.Data.Slug, "Count": 1}
+	how_to_txt := m.ctx.Localizer.Localizer.MustLocalize(&i18n.LocalizeConfig{
+		DefaultMessage: howToPullInstructions,
+		TemplateData:   howToPullInstructionsTemplate,
+	})
 	cmd := fmt.Sprintf("$ docker pull %s", m.repo.Data.Slug)
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		dockerPullCmdTitle.Render(fmt.Sprintf("%s %s?", how_to_txt, m.repo.Data.Name)), // TODO: use translation template
+		dockerPullCmdTitle.Render(how_to_txt),
 		dockerPullCmdBox.Copy().Render(cmd),
 	)
 }

--- a/internal/ui/components/sidebar/my_repos/my_repos.go
+++ b/internal/ui/components/sidebar/my_repos/my_repos.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 	data_user "github.com/victorbersy/docker-hub-cli/internal/data/user"
 	repository_user "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/user"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/components/sidebar"
@@ -55,9 +54,9 @@ func (m *Model) renderName() string {
 }
 
 func (m *Model) renderVisibility() string {
-	visibility_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_visibility"})
-	private_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_visibility_private"})
-	public_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_visibility_public"})
+	visibility_txt := m.ctx.Localizer.T("my_repos_sidebar_visibility")
+	private_txt := m.ctx.Localizer.T("my_repos_sidebar_visibility_private")
+	public_txt := m.ctx.Localizer.T("my_repos_sidebar_visibility_public")
 	var visibility string
 	if m.repo.Data.IsPrivate {
 		visibility = visibilityPrivate.Render(fmt.Sprintf("%s %s", styles.DefaultGlyphs.Private, private_txt))
@@ -74,7 +73,7 @@ func (m *Model) renderVisibility() string {
 func (m *Model) renderStats() string {
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		sidebar.Title.Render(fmt.Sprintf("%s:", m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_stats"}))),
+		sidebar.Title.Render(fmt.Sprintf("%s:", m.ctx.Localizer.T("my_repos_sidebar_stats"))),
 		lipgloss.JoinHorizontal(
 			lipgloss.Top,
 			statsStars.Render(styles.DefaultGlyphs.StatsStars),
@@ -89,9 +88,9 @@ func (m *Model) renderStats() string {
 }
 
 func (m *Model) renderTimestamps() string {
-	timestamps_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_timestamps"})
-	updated_at_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_updated_at"})
-	created_at_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_created_at"})
+	timestamps_txt := m.ctx.Localizer.T("my_repos_sidebar_timestamps")
+	updated_at_txt := m.ctx.Localizer.T("my_repos_sidebar_updated_at")
+	created_at_txt := m.ctx.Localizer.T("my_repos_sidebar_created_at")
 	updated_at := sidebar.AttributeName.Render(fmt.Sprintf("%s:", updated_at_txt))
 	created_at := sidebar.AttributeName.Render(fmt.Sprintf("%s:", created_at_txt))
 	return lipgloss.JoinVertical(

--- a/internal/ui/components/sidebar/my_repos/my_repos.go
+++ b/internal/ui/components/sidebar/my_repos/my_repos.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
 	data_user "github.com/victorbersy/docker-hub-cli/internal/data/user"
 	repository_user "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/user"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/components/sidebar"
+	"github.com/victorbersy/docker-hub-cli/internal/ui/context"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/styles"
 	"github.com/victorbersy/docker-hub-cli/internal/utils"
 )
@@ -14,9 +16,10 @@ import (
 type Model struct {
 	repo  *repository_user.Repository
 	width int
+	ctx   *context.ProgramContext
 }
 
-func NewModel(data *data_user.Repository, width int) Model {
+func NewModel(data *data_user.Repository, width int, ctx *context.ProgramContext) Model {
 	var r *repository_user.Repository
 	if data == nil {
 		r = nil
@@ -26,6 +29,7 @@ func NewModel(data *data_user.Repository, width int) Model {
 	return Model{
 		repo:  r,
 		width: width,
+		ctx:   ctx,
 	}
 }
 
@@ -51,15 +55,18 @@ func (m *Model) renderName() string {
 }
 
 func (m *Model) renderVisibility() string {
+	visibility_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_visibility"})
+	private_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_visibility_private"})
+	public_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_visibility_public"})
 	var visibility string
 	if m.repo.Data.IsPrivate {
-		visibility = visibilityPrivate.Render(fmt.Sprintf("%s Private", styles.DefaultGlyphs.Private))
+		visibility = visibilityPrivate.Render(fmt.Sprintf("%s %s", styles.DefaultGlyphs.Private, private_txt))
 	} else {
-		visibility = visibilityPublic.Render(fmt.Sprintf("%s Public", styles.DefaultGlyphs.Public))
+		visibility = visibilityPublic.Render(fmt.Sprintf("%s %s", styles.DefaultGlyphs.Public, public_txt))
 	}
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		sidebar.Title.Render("Visibility:"),
+		sidebar.Title.Render(fmt.Sprintf("%s:", visibility_txt)),
 		visibility,
 	)
 }
@@ -67,7 +74,7 @@ func (m *Model) renderVisibility() string {
 func (m *Model) renderStats() string {
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		sidebar.Title.Render("Stats:"),
+		sidebar.Title.Render(fmt.Sprintf("%s:", m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_stats"}))),
 		lipgloss.JoinHorizontal(
 			lipgloss.Top,
 			statsStars.Render(styles.DefaultGlyphs.StatsStars),
@@ -82,11 +89,14 @@ func (m *Model) renderStats() string {
 }
 
 func (m *Model) renderTimestamps() string {
-	updated_at := sidebar.AttributeName.Render("Last update:")
-	created_at := sidebar.AttributeName.Render("Created at:")
+	timestamps_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_timestamps"})
+	updated_at_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_updated_at"})
+	created_at_txt := m.ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repos_sidebar_created_at"})
+	updated_at := sidebar.AttributeName.Render(fmt.Sprintf("%s:", updated_at_txt))
+	created_at := sidebar.AttributeName.Render(fmt.Sprintf("%s:", created_at_txt))
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		sidebar.Title.Render("Timestamps:"),
+		sidebar.Title.Render(fmt.Sprintf("%s:", timestamps_txt)),
 		fmt.Sprintf("%s %s", updated_at, utils.TimeElapsed(m.repo.Data.UpdatedAt)),
 		fmt.Sprintf("%s %s", created_at, utils.TimeElapsed(m.repo.Data.CreatedAt)),
 	)

--- a/internal/ui/components/sidebar/my_repos/my_repos.go
+++ b/internal/ui/components/sidebar/my_repos/my_repos.go
@@ -54,9 +54,9 @@ func (m *Model) renderName() string {
 }
 
 func (m *Model) renderVisibility() string {
-	visibility_txt := m.ctx.Localizer.T("my_repos_sidebar_visibility")
-	private_txt := m.ctx.Localizer.T("my_repos_sidebar_visibility_private")
-	public_txt := m.ctx.Localizer.T("my_repos_sidebar_visibility_public")
+	visibility_txt := m.ctx.Localizer.L("my_repos_sidebar_visibility")
+	private_txt := m.ctx.Localizer.L("my_repos_sidebar_visibility_private")
+	public_txt := m.ctx.Localizer.L("my_repos_sidebar_visibility_public")
 	var visibility string
 	if m.repo.Data.IsPrivate {
 		visibility = visibilityPrivate.Render(fmt.Sprintf("%s %s", styles.DefaultGlyphs.Private, private_txt))
@@ -73,7 +73,7 @@ func (m *Model) renderVisibility() string {
 func (m *Model) renderStats() string {
 	return lipgloss.JoinVertical(
 		lipgloss.Top,
-		sidebar.Title.Render(fmt.Sprintf("%s:", m.ctx.Localizer.T("my_repos_sidebar_stats"))),
+		sidebar.Title.Render(fmt.Sprintf("%s:", m.ctx.Localizer.L("my_repos_sidebar_stats"))),
 		lipgloss.JoinHorizontal(
 			lipgloss.Top,
 			statsStars.Render(styles.DefaultGlyphs.StatsStars),
@@ -88,9 +88,9 @@ func (m *Model) renderStats() string {
 }
 
 func (m *Model) renderTimestamps() string {
-	timestamps_txt := m.ctx.Localizer.T("my_repos_sidebar_timestamps")
-	updated_at_txt := m.ctx.Localizer.T("my_repos_sidebar_updated_at")
-	created_at_txt := m.ctx.Localizer.T("my_repos_sidebar_created_at")
+	timestamps_txt := m.ctx.Localizer.L("my_repos_sidebar_timestamps")
+	updated_at_txt := m.ctx.Localizer.L("my_repos_sidebar_updated_at")
+	created_at_txt := m.ctx.Localizer.L("my_repos_sidebar_created_at")
 	updated_at := sidebar.AttributeName.Render(fmt.Sprintf("%s:", updated_at_txt))
 	created_at := sidebar.AttributeName.Render(fmt.Sprintf("%s:", created_at_txt))
 	return lipgloss.JoinVertical(

--- a/internal/ui/components/view/explore/explore.go
+++ b/internal/ui/components/view/explore/explore.go
@@ -34,8 +34,8 @@ func NewModel(id int, ctx *context.ProgramContext) Model {
 		},
 	}
 
-	repositories := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explorer_repositories_item_type_label"})
-	repositories_not_found := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explorer_repositories_not_found"})
+	repositories := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_repositories_item_type_label"})
+	repositories_not_found := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_repositories_not_found"})
 
 	m.view.Table = table.NewModel(
 		m.view.GetDimensions(),
@@ -75,7 +75,7 @@ func (m Model) Update(msg tea.Msg) (view.View, tea.Cmd) {
 }
 
 func (m *Model) View() string {
-	fetching_repositories := m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explorer_repositories_fetching"})
+	fetching_repositories := m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_repositories_fetching"})
 	var spinnerText *string
 	if m.view.IsLoading {
 		spinnerText = utils.StringPtr(lipgloss.JoinHorizontal(lipgloss.Top,

--- a/internal/ui/components/view/explore/explore.go
+++ b/internal/ui/components/view/explore/explore.go
@@ -4,6 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/victorbersy/docker-hub-cli/internal/data"
 	data_search "github.com/victorbersy/docker-hub-cli/internal/data/search"
 	repository_search "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/search"
@@ -33,12 +34,15 @@ func NewModel(id int, ctx *context.ProgramContext) Model {
 		},
 	}
 
+	repositories := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explorer_repositories_item_type_label"})
+	repositories_not_found := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explorer_repositories_not_found"})
+
 	m.view.Table = table.NewModel(
 		m.view.GetDimensions(),
 		m.GetViewColumns(),
 		m.BuildRows(),
-		"Repositories",
-		utils.StringPtr(emptyStateStyle.Render("No repositories were found")),
+		repositories,
+		utils.StringPtr(emptyStateStyle.Render(repositories_not_found)),
 	)
 
 	return m
@@ -71,11 +75,12 @@ func (m Model) Update(msg tea.Msg) (view.View, tea.Cmd) {
 }
 
 func (m *Model) View() string {
+	fetching_repositories := m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explorer_repositories_fetching"})
 	var spinnerText *string
 	if m.view.IsLoading {
 		spinnerText = utils.StringPtr(lipgloss.JoinHorizontal(lipgloss.Top,
 			spinnerStyle.Copy().Render(m.view.Spinner.View()),
-			"Fetching Repositories...",
+			fetching_repositories,
 		))
 	}
 
@@ -98,9 +103,11 @@ func renderColumnTitleLabels() string {
 }
 
 func (m *Model) GetViewColumns() []table.Column {
+	explore_column_updated_at := view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_updated_at"}))
+	explore_column_updated_at_width := (lipgloss.Width(explore_column_updated_at) + 2)
 	return []table.Column{
 		{
-			Title: view.ColumnTitle.Render("Name"),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_name"})),
 			Width: &nameWidth,
 		},
 		{
@@ -108,7 +115,7 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &labelsWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render("Organization"),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_organization"})),
 			Width: &organizationsnameWidth,
 		},
 		{
@@ -120,11 +127,11 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &statsWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render("Updated At"),
-			Width: &LastUpdateCellWidth,
+			Title: explore_column_updated_at,
+			Width: &explore_column_updated_at_width,
 		},
 		{
-			Title: view.ColumnTitle.Render("Description"),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_description"})),
 			Grow:  utils.BoolPtr(true),
 		},
 	}

--- a/internal/ui/components/view/explore/explore.go
+++ b/internal/ui/components/view/explore/explore.go
@@ -4,7 +4,6 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/victorbersy/docker-hub-cli/internal/data"
 	data_search "github.com/victorbersy/docker-hub-cli/internal/data/search"
 	repository_search "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/search"
@@ -34,8 +33,8 @@ func NewModel(id int, ctx *context.ProgramContext) Model {
 		},
 	}
 
-	repositories := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_repositories_item_type_label"})
-	repositories_not_found := ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_repositories_not_found"})
+	repositories := ctx.Localizer.T("explore_repositories_item_type_label")
+	repositories_not_found := ctx.Localizer.T("explore_repositories_not_found")
 
 	m.view.Table = table.NewModel(
 		m.view.GetDimensions(),
@@ -75,7 +74,7 @@ func (m Model) Update(msg tea.Msg) (view.View, tea.Cmd) {
 }
 
 func (m *Model) View() string {
-	fetching_repositories := m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "explore_repositories_fetching"})
+	fetching_repositories := m.view.Ctx.Localizer.T("explore_repositories_fetching")
 	var spinnerText *string
 	if m.view.IsLoading {
 		spinnerText = utils.StringPtr(lipgloss.JoinHorizontal(lipgloss.Top,
@@ -103,11 +102,11 @@ func renderColumnTitleLabels() string {
 }
 
 func (m *Model) GetViewColumns() []table.Column {
-	explore_column_updated_at := view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_updated_at"}))
+	explore_column_updated_at := view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_updated_at"))
 	explore_column_updated_at_width := (lipgloss.Width(explore_column_updated_at) + 2)
 	return []table.Column{
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_name"})),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_name")),
 			Width: &nameWidth,
 		},
 		{
@@ -115,7 +114,7 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &labelsWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_organization"})),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_organization")),
 			Width: &organizationsnameWidth,
 		},
 		{
@@ -131,7 +130,7 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &explore_column_updated_at_width,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_description"})),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_description")),
 			Grow:  utils.BoolPtr(true),
 		},
 	}

--- a/internal/ui/components/view/explore/explore.go
+++ b/internal/ui/components/view/explore/explore.go
@@ -33,8 +33,8 @@ func NewModel(id int, ctx *context.ProgramContext) Model {
 		},
 	}
 
-	repositories := ctx.Localizer.T("explore_repositories_item_type_label")
-	repositories_not_found := ctx.Localizer.T("explore_repositories_not_found")
+	repositories := ctx.Localizer.L("explore_repositories_item_type_label")
+	repositories_not_found := ctx.Localizer.L("explore_repositories_not_found")
 
 	m.view.Table = table.NewModel(
 		m.view.GetDimensions(),
@@ -74,7 +74,7 @@ func (m Model) Update(msg tea.Msg) (view.View, tea.Cmd) {
 }
 
 func (m *Model) View() string {
-	fetching_repositories := m.view.Ctx.Localizer.T("explore_repositories_fetching")
+	fetching_repositories := m.view.Ctx.Localizer.L("explore_repositories_fetching")
 	var spinnerText *string
 	if m.view.IsLoading {
 		spinnerText = utils.StringPtr(lipgloss.JoinHorizontal(lipgloss.Top,
@@ -102,11 +102,11 @@ func renderColumnTitleLabels() string {
 }
 
 func (m *Model) GetViewColumns() []table.Column {
-	explore_column_updated_at := view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_updated_at"))
+	explore_column_updated_at := view.ColumnTitle.Render(m.view.Ctx.Localizer.L("column_header_updated_at"))
 	explore_column_updated_at_width := (lipgloss.Width(explore_column_updated_at) + 2)
 	return []table.Column{
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_name")),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.L("column_header_name")),
 			Width: &nameWidth,
 		},
 		{
@@ -114,7 +114,7 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &labelsWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_organization")),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.L("column_header_organization")),
 			Width: &organizationsnameWidth,
 		},
 		{
@@ -130,7 +130,7 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &explore_column_updated_at_width,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_description")),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.L("column_header_description")),
 			Grow:  utils.BoolPtr(true),
 		},
 	}

--- a/internal/ui/components/view/explore/styles.go
+++ b/internal/ui/components/view/explore/styles.go
@@ -9,7 +9,6 @@ import (
 var (
 	nameWidth              = 25
 	organizationsnameWidth = 20
-	LastUpdateCellWidth    = lipgloss.Width(" Last Update ")
 	labelsWidth            = 12
 	statsWidth             = 8
 

--- a/internal/ui/components/view/my_repos/my_repos.go
+++ b/internal/ui/components/view/my_repos/my_repos.go
@@ -4,6 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/victorbersy/docker-hub-cli/internal/data"
 	data_user "github.com/victorbersy/docker-hub-cli/internal/data/user"
 	repository_user "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/user"
@@ -37,12 +38,12 @@ func NewModel(id int, ctx *context.ProgramContext) Model {
 		m.view.GetDimensions(),
 		m.GetViewColumns(),
 		m.BuildRows(),
-		"Repositories",
+		m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_item_type_label"}),
 		utils.StringPtr(
 			lipgloss.JoinVertical(
 				lipgloss.Top,
-				emptyStateStyle.Render("No repositories found."),
-				emptyStateStyle.Render("Have you set DOCKER_USERNAME and DOCKER_BEARER?"),
+				emptyStateStyle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_not_found"})),
+				emptyStateStyle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_not_found_tip"})),
 			),
 		),
 	)
@@ -81,7 +82,7 @@ func (m *Model) View() string {
 	if m.view.IsLoading {
 		spinnerText = utils.StringPtr(lipgloss.JoinHorizontal(lipgloss.Top,
 			spinnerStyle.Copy().Render(m.view.Spinner.View()),
-			"Fetching nothing...",
+			m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_fetching"}),
 		))
 	}
 
@@ -97,7 +98,7 @@ func (m *Model) UpdateProgramContext(ctx *context.ProgramContext) {
 func (m *Model) GetViewColumns() []table.Column {
 	return []table.Column{
 		{
-			Title: view.ColumnTitle.Render("Name"),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_name"})),
 			Grow:  utils.BoolPtr(true),
 		},
 		{
@@ -113,11 +114,11 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &statsWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render("Last Update"),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_updated_at"})),
 			Width: &updatedAtWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render("Created"),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_created_at"})),
 			Width: &createdAtWidth,
 		},
 	}

--- a/internal/ui/components/view/my_repos/my_repos.go
+++ b/internal/ui/components/view/my_repos/my_repos.go
@@ -37,12 +37,12 @@ func NewModel(id int, ctx *context.ProgramContext) Model {
 		m.view.GetDimensions(),
 		m.GetViewColumns(),
 		m.BuildRows(),
-		m.view.Ctx.Localizer.T("my_repositories_item_type_label"),
+		m.view.Ctx.Localizer.L("my_repositories_item_type_label"),
 		utils.StringPtr(
 			lipgloss.JoinVertical(
 				lipgloss.Top,
-				emptyStateStyle.Render(m.view.Ctx.Localizer.T("my_repositories_not_found")),
-				emptyStateStyle.Render(m.view.Ctx.Localizer.T("my_repositories_not_found_tip")),
+				emptyStateStyle.Render(m.view.Ctx.Localizer.L("my_repositories_not_found")),
+				emptyStateStyle.Render(m.view.Ctx.Localizer.L("my_repositories_not_found_tip")),
 			),
 		),
 	)
@@ -81,7 +81,7 @@ func (m *Model) View() string {
 	if m.view.IsLoading {
 		spinnerText = utils.StringPtr(lipgloss.JoinHorizontal(lipgloss.Top,
 			spinnerStyle.Copy().Render(m.view.Spinner.View()),
-			m.view.Ctx.Localizer.T("my_repositories_fetching"),
+			m.view.Ctx.Localizer.L("my_repositories_fetching"),
 		))
 	}
 
@@ -97,7 +97,7 @@ func (m *Model) UpdateProgramContext(ctx *context.ProgramContext) {
 func (m *Model) GetViewColumns() []table.Column {
 	return []table.Column{
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_name")),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.L("column_header_name")),
 			Grow:  utils.BoolPtr(true),
 		},
 		{
@@ -113,11 +113,11 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &statsWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_updated_at")),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.L("column_header_updated_at")),
 			Width: &updatedAtWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_created_at")),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.L("column_header_created_at")),
 			Width: &createdAtWidth,
 		},
 	}

--- a/internal/ui/components/view/my_repos/my_repos.go
+++ b/internal/ui/components/view/my_repos/my_repos.go
@@ -4,7 +4,6 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/victorbersy/docker-hub-cli/internal/data"
 	data_user "github.com/victorbersy/docker-hub-cli/internal/data/user"
 	repository_user "github.com/victorbersy/docker-hub-cli/internal/ui/components/repository/user"
@@ -38,12 +37,12 @@ func NewModel(id int, ctx *context.ProgramContext) Model {
 		m.view.GetDimensions(),
 		m.GetViewColumns(),
 		m.BuildRows(),
-		m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_item_type_label"}),
+		m.view.Ctx.Localizer.T("my_repositories_item_type_label"),
 		utils.StringPtr(
 			lipgloss.JoinVertical(
 				lipgloss.Top,
-				emptyStateStyle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_not_found"})),
-				emptyStateStyle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_not_found_tip"})),
+				emptyStateStyle.Render(m.view.Ctx.Localizer.T("my_repositories_not_found")),
+				emptyStateStyle.Render(m.view.Ctx.Localizer.T("my_repositories_not_found_tip")),
 			),
 		),
 	)
@@ -82,7 +81,7 @@ func (m *Model) View() string {
 	if m.view.IsLoading {
 		spinnerText = utils.StringPtr(lipgloss.JoinHorizontal(lipgloss.Top,
 			spinnerStyle.Copy().Render(m.view.Spinner.View()),
-			m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "my_repositories_fetching"}),
+			m.view.Ctx.Localizer.T("my_repositories_fetching"),
 		))
 	}
 
@@ -98,7 +97,7 @@ func (m *Model) UpdateProgramContext(ctx *context.ProgramContext) {
 func (m *Model) GetViewColumns() []table.Column {
 	return []table.Column{
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_name"})),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_name")),
 			Grow:  utils.BoolPtr(true),
 		},
 		{
@@ -114,11 +113,11 @@ func (m *Model) GetViewColumns() []table.Column {
 			Width: &statsWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_updated_at"})),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_updated_at")),
 			Width: &updatedAtWidth,
 		},
 		{
-			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "column_header_created_at"})),
+			Title: view.ColumnTitle.Render(m.view.Ctx.Localizer.T("column_header_created_at")),
 			Width: &createdAtWidth,
 		},
 	}

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -1,8 +1,8 @@
 package context
 
 import (
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/victorbersy/docker-hub-cli/internal/config"
+	"github.com/victorbersy/docker-hub-cli/internal/config/locales"
 )
 
 type ProgramContext struct {
@@ -12,7 +12,7 @@ type ProgramContext struct {
 	MainContentHeight int
 	Config            *config.Config
 	View              config.ViewType
-	Localizer         *i18n.Localizer
+	Localizer         locales.Locales
 }
 
 func (ctx *ProgramContext) GetViewsConfig() []config.ViewConfig {

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/victorbersy/docker-hub-cli/internal/config"
 )
 
@@ -11,6 +12,7 @@ type ProgramContext struct {
 	MainContentHeight int
 	Config            *config.Config
 	View              config.ViewType
+	Localizer         *i18n.Localizer
 }
 
 func (ctx *ProgramContext) GetViewsConfig() []config.ViewConfig {

--- a/internal/ui/styles/glyphs.go
+++ b/internal/ui/styles/glyphs.go
@@ -1,6 +1,9 @@
 package styles
 
 type Glyphs struct {
+	TabExplore string
+	TabMyRepos string
+
 	LabelCommunity         string
 	LabelDockerOfficial    string
 	LabelOpenSourceProgram string
@@ -15,6 +18,9 @@ type Glyphs struct {
 }
 
 var DefaultGlyphs = Glyphs{
+	TabExplore: "",
+	TabMyRepos: "",
+
 	LabelCommunity:         "וֹ",
 	LabelDockerOfficial:    "",
 	LabelOpenSourceProgram: "",

--- a/internal/ui/ui_model.go
+++ b/internal/ui/ui_model.go
@@ -37,7 +37,7 @@ func NewModel() Model {
 		tabs: tabsModel,
 		ctx: context.ProgramContext{
 			Config:    &config.Config{},
-			Localizer: locales.GetLocalizer(),
+			Localizer: locales.NewLocales(),
 		},
 	}
 }

--- a/internal/ui/ui_model.go
+++ b/internal/ui/ui_model.go
@@ -4,6 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/victorbersy/docker-hub-cli/internal/config"
+	"github.com/victorbersy/docker-hub-cli/internal/config/locales"
 	data_search "github.com/victorbersy/docker-hub-cli/internal/data/search"
 	data_user "github.com/victorbersy/docker-hub-cli/internal/data/user"
 	"github.com/victorbersy/docker-hub-cli/internal/ui/components/help"
@@ -35,7 +36,8 @@ func NewModel() Model {
 		help: help.NewModel(),
 		tabs: tabsModel,
 		ctx: context.ProgramContext{
-			Config: &config.Config{},
+			Config:    &config.Config{},
+			Localizer: locales.GetLocalizer(),
 		},
 	}
 }

--- a/internal/ui/ui_model.go
+++ b/internal/ui/ui_model.go
@@ -159,10 +159,10 @@ func (m *Model) syncSidebar() {
 	width := m.sidebar.GetSidebarContentWidth()
 	switch data := currRowData.(type) {
 	case *data_search.Repository:
-		content := explore_sidebar.NewModel(data, width).View()
+		content := explore_sidebar.NewModel(data, width, &m.ctx).View()
 		m.sidebar.SetContent(content)
 	case *data_user.Repository:
-		content := my_repos_sidebar.NewModel(data, width).View()
+		content := my_repos_sidebar.NewModel(data, width, &m.ctx).View()
 		m.sidebar.SetContent(content)
 	}
 }

--- a/internal/ui/ui_view.go
+++ b/internal/ui/ui_view.go
@@ -17,6 +17,7 @@ func (m Model) View() string {
 	}
 
 	if m.ctx.Config == nil {
+		m.ctx.Localizer.L("startup_reading")
 		return "Reading config...\n"
 	}
 

--- a/internal/ui/ui_view.go
+++ b/internal/ui/ui_view.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,8 +18,7 @@ func (m Model) View() string {
 	}
 
 	if m.ctx.Config == nil {
-		m.ctx.Localizer.L("startup_reading")
-		return "Reading config...\n"
+		return fmt.Sprintln(m.ctx.Localizer.L("startup_reading"))
 	}
 
 	s := strings.Builder{}
@@ -33,7 +33,7 @@ func (m Model) View() string {
 			m.sidebar.View(),
 		)
 	} else {
-		mainContent = "No views defined..."
+		mainContent = fmt.Sprintln(m.ctx.Localizer.L("startup_no_views_defined"))
 	}
 	s.WriteString(mainContent)
 	s.WriteString("\n")


### PR DESCRIPTION
This PR aims to add translation options to the application.

It's not a big deal to not have that, but it's more than welcome. And the earlier is taken care of, the easier it will be to translate the application.

One last thing missing is the text used in `utils/utils.go` for timestamp, like "X days ago".

I think I could (and should!) make the translation function shorter to use.